### PR TITLE
优化 Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.8-slim-buster
 
 RUN mkdir /app
 
@@ -10,7 +10,7 @@ RUN cd /app \
     && pip3 install --no-cache-dir -r requirements.txt --extra-index-url https://pypi.douban.com/simple/ \
     && rm -rf /tmp/* && rm -rf /root/.cache/* \
     && sed -i 's#http://deb.debian.org#http://mirrors.aliyun.com/#g' /etc/apt/sources.list\
-    && apt-get --allow-releaseinfo-change update && apt install libgl1-mesa-glx -y
+    && apt-get --allow-releaseinfo-change update && apt install libgl1-mesa-glx libglib2.0-0 -y
 
 WORKDIR /app
 


### PR DESCRIPTION
1. 使用 buster-slim, 减小约 300M 体积占用.
2. 添加 libglib2.0-0 依赖. (发现在阿里云函数 FC 上运行时缺少该依赖报错.)